### PR TITLE
Increase the plugin's resiliency when working with the file system

### DIFF
--- a/lib/logstash/outputs/kusto.rb
+++ b/lib/logstash/outputs/kusto.rb
@@ -134,6 +134,11 @@ class LogStash::Outputs::Kusto < LogStash::Outputs::Base
 
     @ingestor = Ingestor.new(ingest_url, app_id, app_key, app_tenant, database, table, mapping, delete_temp_files, @logger, executor)
 
+    # send existing files
+    recover_past_files if recovery
+
+    @last_stale_cleanup_cycle = Time.now
+
     @flush_interval = @flush_interval.to_i
     if @flush_interval > 0
       @flusher = Interval.start(@flush_interval, -> { flush_pending_files })
@@ -142,11 +147,6 @@ class LogStash::Outputs::Kusto < LogStash::Outputs::Base
     if (@stale_cleanup_type == 'interval') && (@stale_cleanup_interval > 0)
       @cleaner = Interval.start(stale_cleanup_interval, -> { close_stale_files })
     end
-
-    @last_stale_cleanup_cycle = Time.now
-
-    # send existing files
-    recover_past_files if recovery
   end
 
   private

--- a/lib/logstash/outputs/kusto.rb
+++ b/lib/logstash/outputs/kusto.rb
@@ -360,9 +360,11 @@ class LogStash::Outputs::Kusto < LogStash::Outputs::Base
     pattern_start = @path.index('%') || path_last_char
     last_folder_before_pattern = @path.rindex('/', pattern_start) || path_last_char
     new_path = path[0..last_folder_before_pattern]
-    @logger.info("Going to recover old files in path #{@new_path}")
-
+    
     begin
+      return unless Dir.exist?(new_path)
+      @logger.info("Going to recover old files in path #{@new_path}")
+      
       old_files = Find.find(new_path).select { |p| /.*\.kusto$/ =~ p }
       @logger.info("Found #{old_files.length} old file(s), sending them now...")
 

--- a/lib/logstash/outputs/kusto/ingestor.rb
+++ b/lib/logstash/outputs/kusto/ingestor.rb
@@ -96,6 +96,8 @@ class LogStash::Outputs::Kusto < LogStash::Outputs::Base
       File.delete(path) if delete_on_success
 
       @logger.debug("File #{path} sent to kusto.")
+    rescue Errno::ENOENT => e
+      @logger.error("File doesn't exist! Unrecoverable error.", exception: e.class, message: e.message, path: path, backtrace: e.backtrace)
     rescue Java::JavaNioFile::NoSuchFileException => e
       @logger.error("File doesn't exist! Unrecoverable error.", exception: e.class, message: e.message, path: path, backtrace: e.backtrace)
     rescue => e


### PR DESCRIPTION
Includes a few small changes:

- `upload` - Stopping retries on ruby's exception on top of java's.
- `register` - Recover past files before starting the flush and cleanup intervals.
- `recover_past_files` - Don't assume the path already exists