### PR TITLE
Run CI only on release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: bundler
 matrix:
   include:
   - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=7.0
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=6.7


### PR DESCRIPTION
They seem to have broken their master branch with this:

```
/home/travis/build/logstash/logstash-core/src/main/java/co/elastic/logstash/api/Codec.java:51: warning: no @throws for java.io.IOException
    void encode(Event event, OutputStream output) throws IOException;
```

I don't think we really need to make sure we work with their master as long as the releases work...