### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         id: set_artifact_name
         run: |
           ARTIFACT_PATH=$(find . -maxdepth 1 -iname '*.gem')
-          echo "::set-output name=artifact_name::$ARTIFACT_PATH"
+          echo "artifact_name=$ARTIFACT_PATH" >> $GITHUB_OUTPUT
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter`